### PR TITLE
Add marker letter exclusion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Finally, you can use the Evil keybindings `m-*` and `'-*` to set and get marker.
 
 Note that `helm-evil-markers` supports **evil global markers** (marked with captical letters) to switch
 between buffers.
+
+## Customization
+
+If you would like to exclude particular mark letters from selection menu, you may add them to the `helm-evil-markers-exclude-marks`. By default this list will contain `^`, `[`, `]` special marks. Also exclusion is disabled by default, to use exclusion rules, you need to set `helm-evil-markers-exclusion-enabled` to a non-nil value beforehand.

--- a/helm-evil-markers.el
+++ b/helm-evil-markers.el
@@ -37,6 +37,16 @@
    (replace-regexp-in-string "\n$" "" (thing-at-point 'line))
    helm-evil-markers-hint-max-length))
 
+(defcustom helm-evil-markers-exclusion-enabled nil
+  "Whether to use helm-evil-markers-exclude-marks to filter out marker list."
+  :type 'boolean
+  :group 'helm-evil-markers)
+
+(defcustom helm-evil-markers-exclude-marks '("^" "[" "]")
+  "Marks which should not be displayed on selection menu."
+  :type '(repeat string)
+  :group 'helm-evil-markers)
+
 (defun helm-evil-markers-update-alist ()
   "Update cached evil markers alist."
   (setq helm-evil-markers-alist nil)
@@ -76,7 +86,12 @@
   (unless (and (equal helm-evil-markers-buffer-name (buffer-name))
                (equal helm-evil-markers-tick (buffer-chars-modified-tick)))
     (helm-evil-markers-update-alist))
-  helm-evil-markers-alist)
+  (if helm-evil-markers-exclusion-enabled
+      (seq-filter
+       (lambda (str)
+         (not (member (substring (car str) 0 1) helm-evil-markers-exclude-marks)))
+       helm-evil-markers-alist)
+    helm-evil-markers-alist))
 
 (defun helm-evil-markers-sort (candidates _source)
   "Custom sorting for matching CANDIDATES from SOURCE."


### PR DESCRIPTION
When `helm-evil-markers-exclusion-enabled` is set to a non-nil value,
helm-evil-markers will filter out the marker letters defined in the
`helm-evil-markers-exclude-marks`.

The special mark letters are distracting and I never use them. So I simply
added an option to filter them out before displaying the selection menu. This
is something I did for my usage but I thought other people may also be
interested in this. Also I'm not quite sure if this is the best way to
implement this feature but seems to work fine. I wanted it to be toggleable.

Also thanks for this plugin! I started to implement something like this and
then thought _probably someone else did it before and better_ and then found
this.